### PR TITLE
Remove space after emoji

### DIFF
--- a/modules/mod.js
+++ b/modules/mod.js
@@ -159,7 +159,7 @@ export async function findAndPlaceBadges(
       }
 
       core.debug(`Found repo: ${baseUrl}, setting status to ${emoji}`);
-      return `${baseUrl}${tail ? `${tail}` : ""} ${emoji} `;
+      return `${baseUrl}${tail ? `${tail}` : ""} ${emoji}`;
     }
   );
 


### PR DESCRIPTION
Looks odd before a comma as in our case, otherwise the emoji will end where the repo name/link did which is probably preferred.